### PR TITLE
Fix horus decode: drop pcmrecord --ssrc filter on static channels

### DIFF
--- a/ground_station/horusdemodlib/docker_ka9q_single.sh
+++ b/ground_station/horusdemodlib/docker_ka9q_single.sh
@@ -15,8 +15,8 @@
 #       ka9q-radio/radiod.conf with its own PCM multicast stream (SDR_DEVICE),
 #       so we no longer `tune` here. This avoids every pcmrecord sharing one
 #       multicast group and receiving all channels' IQ (an O(N^2) kernel fan-out
-#       that was burning ~35% sys CPU). radiod auto-assigns the static SSRC as
-#       the frequency in kHz, i.e. RXFREQ/1000.
+#       that was burning ~35% sys CPU). Each channel's group carries exactly one
+#       stream, so pcmrecord reads it with no --ssrc filter (like wenet).
 #
 
 set -e
@@ -32,9 +32,6 @@ STARTUP_JITTER="${STARTUP_JITTER:-15}"
 FSK_LOWER=$(echo "$RXBANDWIDTH / -2" | bc)
 FSK_UPPER=$(echo "$RXBANDWIDTH / 2" | bc)
 
-# Static-channel SSRC convention used by radiod: frequency in kHz.
-SSRC=$(($RXFREQ / 1000))
-
 # Spread out startup so a bulk `up` doesn't slam pcmrecord all at once.
 if [ "$STARTUP_JITTER" -gt 0 ]; then
     DELAY=$((RANDOM % STARTUP_JITTER))
@@ -43,8 +40,7 @@ if [ "$STARTUP_JITTER" -gt 0 ]; then
 fi
 
 echo "Using SDR Centre Frequency: $RXFREQ Hz"
-echo "Using SSRC: $SSRC (static channel in radiod.conf)"
-echo "Using PCM stream: $SDR_DEVICE"
+echo "Using PCM stream: $SDR_DEVICE (dedicated static channel in radiod.conf)"
 echo "Using FSK estimation range: $FSK_LOWER - $FSK_UPPER Hz"
 
 # Start the receive chain. The channel is defined statically in radiod.conf, so
@@ -52,7 +48,7 @@ echo "Using FSK estimation range: $FSK_LOWER - $FSK_UPPER Hz"
 # We pass in the SDR centre frequency ($RXFREQ) and 'target' signal frequency
 # ($RXFREQ) to provide additional metadata to Habitat / Sondehub.
 echo "Starting receiver chain"
-pcmrecord --ssrc $SSRC --catmode --raw $SDR_DEVICE --timeout $PCM_TIMEOUT | \
+pcmrecord --catmode --raw $SDR_DEVICE --timeout $PCM_TIMEOUT | \
   $DECODER -q --stats=5 -g -m binary --fsk_lower=$FSK_LOWER --fsk_upper=$FSK_UPPER - - | \
   python3 -m horusdemodlib.uploader --freq_hz $RXFREQ --freq_target_hz $RXFREQ $@ &
 


### PR DESCRIPTION
The static [horus-*] channels each have their own dedicated PCM multicast group, but docker_ka9q_single.sh filtered the stream with `pcmrecord --ssrc $((RXFREQ / 1000))` (frequency in kHz, e.g. 432900).

radiod actually stamps these static channels with SSRC = frequency in Hz (e.g. 432900000; "start_demod: ssrc 432900000, output horus-432900-pcm.local" in the radiod log). The kHz filter therefore matched no packets, leaving the demod's stdin empty so nothing ever decoded.

Since each channel now has its own multicast group there is exactly one stream to read, so the --ssrc filter is unnecessary. Drop it entirely, matching the working wenet containers (pcmrecord --catmode --raw, no --ssrc). 